### PR TITLE
[add] element `axis`

### DIFF
--- a/src/components/axis.typ
+++ b/src/components/axis.typ
@@ -10,6 +10,7 @@
 
 
 #import "tick.typ": tick as tick-constructor
+#import "@preview/tiptoe:0.2.0"
 
 
 /// An axis for a diagram. Visually, an axis consists of a _spine_ along the axis direction, a collection of ticks/subticks and an axis label. 
@@ -100,6 +101,16 @@
   /// If set to `true`, the entire axis is hidden. 
   /// -> boolean
   hidden: false,
+
+  /// Places an arrow tip on the axis spine. This expects a mark as specified by
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  tip: none,
+  
+  /// Places an arrow tail on the axis spine. This expects a mark as specified by 
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  toe: none,
 
   /// Plot objects to associate with this axis. This only applies when this is a secondary axis. Automatic limits are then computed according to this axis and transformations of the data coordinates linked to the scaling of this axis. 
   /// -> any
@@ -242,6 +253,8 @@
     auto-exponent-threshold: auto-exponent-threshold,
     plots: plots,
     hidden: hidden,
+    tip: tip,
+    toe: toe,
   )
 }
 
@@ -446,7 +459,7 @@
     place-exp-or-offset = it => place(horizon + right, dx: .5em, dy: 0pt, place(left + horizon, it))
     exp-or-offset-alignment = (alignment: bottom + right, content-alignment: horizon + left)
     exp-or-offset-offset = (dx: .5em, dy: 0pt)
-    spine = line
+    spine = tiptoe.line.with(tip: axis.tip, toe: axis.toe)
   } else if axis.kind == "y" {
     dim = "width"
     place-tick = (y, label, position, inset, outset, stroke: axis.stroke) => {
@@ -466,7 +479,7 @@
     place-exp-or-offset = it => place(top + center, dx: 0pt, dy: -.5em, place(bottom + center, it))
     exp-or-offset-alignment = (alignment: top + left, content-alignment: center + bottom)
     exp-or-offset-offset = (dx: 0pt, dy: -.5em)
-    spine = line.with(angle: 90deg)
+    spine = tiptoe.line.with(angle: 90deg, tip: axis.toe, toe: axis.tip)
   }
 
 

--- a/src/diagram.typ
+++ b/src/diagram.typ
@@ -190,10 +190,22 @@
   
   
   context e.get(e-get => {
-  
+  if yaxis.locate-subticks == none {
+    let p = yaxis
+  }
   let axis-info = (
-    x: (ticking: axis-generate-ticks(xaxis, length: width)), 
-    y: (ticking: axis-generate-ticks(yaxis, length: height)), 
+    x: (ticking: axis-generate-ticks(
+      xaxis, 
+      xaxis.locate-ticks.with(..xaxis.tick-args), 
+      xaxis.locate-subticks.with(..xaxis.subtick-args),
+      kind: "x", length: width, lim: xaxis.lim
+    )), 
+    y: (ticking: axis-generate-ticks(
+      yaxis, 
+      yaxis.locate-ticks.with(..yaxis.tick-args), 
+      yaxis.locate-subticks.with(..yaxis.subtick-args),
+      kind: "y", length: height, lim: yaxis.lim
+    )), 
     rest: ((:),) * axes.len()
   )
     
@@ -207,6 +219,7 @@
     width: width, height: height, 
     inset: 0pt, stroke: none, 
     {
+      
     
 
     let artists = ()
@@ -313,11 +326,17 @@
       type: "major"
     )
     let get-axis-args(axis) = {
-      if axis.kind == "x" { 
-        (length: width)
+      let length = if axis.kind == "x" { 
+        width
       } else {
-        (length: height)
-      }
+        height
+      } 
+      arguments(
+        kind: axis.kind, lim: axis.lim, 
+        axis.locate-ticks.with(..axis.tick-args), 
+        axis.locate-subticks.with(..axis.subtick-args),
+        length: length
+      ) 
     }
     let (xaxis-, max-xtick-size) = draw-axis(xaxis, axis-info.x.ticking, major-axis-style, e-get: e-get)
     artists.push((content: xaxis-, z: 2.1))
@@ -340,7 +359,9 @@
     }
 
     for axis in axes {
-      let ticking = axis-generate-ticks(axis, ..get-axis-args(axis))
+      let ticking = axis-generate-ticks(
+        axis, ..get-axis-args(axis)
+      )
       let (axis-, axis-bounds) = draw-axis(axis, ticking, major-axis-style, e-get: e-get)
       artists.push((content: axis-, z: 2.1))
 


### PR DESCRIPTION
This PR deals with the heavy task of making `axis` an ([elembic](https://github.com/PgBiel/elembic)) element. There are some issues that need to be overcome (each explained in more detail below):
- [ ] Obtaining the computed limits in order to create the `transform` from data to diagram-area coordinates. 
- [ ] Obtaining the ticks computed by `axis` in order to draw the `grid. `
- [ ] Passing the `transform` to the axis when the axis object is already created. 
- [ ] communicating bounds back to `diagram`. 


All of this issues are connected to styling with `set` and `show` rules and are introduced when making `axis` a type (or "element") for two reasons:
1. A type is transformed into content by a (default) `show` rule. By design, the return value of this rule can only be content and has to be treated like a black box. For this reason, no tuples of content and extra information can be returned (as is done momentarily). Note that this argumentation holds, even though content itself is planned to eventually be removed from Typst.
2. Some fields of a type are only populated later, when the type instance is passed to the `show` rule of the type. This process is called realization and in particular applies to _settable_ fields. While a required field like the body can just be queried from the object, e.g., `#heading[hello].body`, settable fields are often not known at this point, e.g., `heading[hello].level`. The `level` is only known when set explicitly as in `#heading(level: 2)[hello]` and otherwise depends on the context where the heading is inserted into the document. 

## No type for axis?

A solution to all these issues is *not to make `axis` a type*. 
Why do we even want to make `axis` a type?

- to enable `show` rules on them
  ```typ
  #show lq.axis: set text(.8em)
  ```
- to enable `set` rules for them, e.g.
  ```typ
  #set lq.axis(position: right, mirror: false)
  #set 
  ```

But maybe this is not the right way to go. Maybe it's enough for `tick` and `spine` (the spine is the line drawn along the axis) to be elements. 

Below, I list all properties of `axis`, sorted by whether I think it is desirable to enable `set` rule for them. 
- Properties that are better set on `diagram` since they need to be independent for the x and y axis. For extra axes, they are not too important:
  - `scale` (e.g., `"linear"` or `"log"`)
  - `lim` (e.g., `(1, 2)` or `auto` or `(-2, auto)`
  - `label` (e.g., `$x$` or `[$t$ in seconds]`)
  - `hidden`
 
- Properties that are useful to be set but only independently for the x and y axis. Same category as the one before but they don't have a direct property in `diagram`. Instead, there is `diagram.xaxis` and `diagram.yaxis` that take a dictionary. It could be used like this:
  ```typ
  #set lq.diagram(xaxis: (position: left))
  #set lq.diagram(xaxis: (mirror: false))
  ```
  - `position` (`left`, `top` etc. )
  - `mirror` (whether to show a mirrored copy of the axis on the other side)
  - `tip` (the arrow tip of the axis)
  - `offset`, `exponent`, `tick-distance`
  - `ticks`, `subticks`
  - `locate-(sub)ticks`, `format-(sub)ticks`

- Properties that basically never need to be `set`
  - `kind` (can be `"x"` or `"y"`)
  - `functions` (only used for extra axes)
  - `extra-ticks`
 
- Could be a property of a type `spine`
  - `stroke`


Regarding all this, it might not be necessary to make `axis` a type. The example
 ```typ
#show lq.axis: set text(.8em)
```
from above can be replaced by 
 ```typ
#show lq.tick: set text(.8em)
#show lq.label: set text(.8em)
```
because these two will definitely be types. 


-----
Now for the detailed discussion of the four problems above. 

### Obtaining the computed limits

The computation the limits along an axis depends on several fields of `axis`
- `axis.lim`: Here, limits can be set to `auto` (then they are computed from the given plots) or a fixed data value. 
- `axis.plots`: When the upper/lower limit is set to `auto`, the corresponding limit is evaluated from the `xlimits` or `ylimits` values of all plots that are assigned to this axis. 
- `axis.kind`: The axis kind (`"x"` or `"y"`) determines whether `xlimits` or `ylimits` are read from the plots. 
- `axis.functions`: Secondary axis that are dependent on another axis but show a different scaling (for example to show the same data in a different physical unit like energy on the main axis and wavelength $λ=c/ν$ on the secondary axis) use this property to transform the given limits to new limits. 
- `axis.scale`: The scale transform and its inverse are used to compute absolute margins for the axis range. The inverse is also used to enhance the limits, when they collapse to a single point. 

Why does this pose a problem? As explained above, the output of a show rule is only content, so we cannot just draw the axis and output the limits along with the drawn axis. 

A solution is to make all these fields non-settable. In this case they are all known from the object (and not just from within the show rule) and diagram can just access them in order to set up the data -> diagram transform. 

This is okay because all these fields are not very practical to set for all axes in generality. Instead, it will be possible to do
```typ
#set lq.diagram(xlim: (1, 0), yscale: "linear")
```
and so on. 

### Obtaining the ticks computed by axis

The same reasoning holds here. We also want the computed ticks outside of the axis in order to draw the `grid`. This computation depends on 
- The length of the axis (in `pt`),
- `axis.kind`,
- the function `axis.locate-ticks`, and
- the computed axis limits. 


### Passing the `transform` to the axis when the axis object is already created. 

This is just a small problem which already has a solution. The transform data coordinates -> diagram coordinates is created in `diagram` from the limits, diagram width/height, `axis.scale` and `diagram.margins`. 

This could be solved via some (private) helper type `transform` and calling
```typ
set transform(x: x-trafo, y: y-trafo)
```
which can be accessed in the `axis` show rule via `transform.x` and `transform.y`. 




### About bounds

In order to wrap the entire diagram nicely in a box or block in a way that no content "sticks" out, we need to compute the bounds of all parts of the diagram. 

Currently this is feasible: the function that draws an axis returns the content of the axis and also its bounds (or even a collection of rectangles for more fine-grained positioning control). Note that the bounds include ticks, tick labels, axis labels as well as exponents/offsets at the end of the axis and can thus only be computed by the axis and not from the outside, i.e. the diagram.

If axis were a type, we can only return content (see above). How can diagram know the bounds of the axis? There are two possible approaches:

- diagram can measure the axis content and retrieve at least the dimensions of the axis object. Note however that these are only two numbers (width, height) while the full bounds comprise four numbers (width/height/x/y or top/bottom/left/right). Consider the y-axis. One could fix the position (x,y) to the diagram origin (lower left corner of the data area). In most cases,
- axis could store its bounds in a metadata that diagram can query. However, this adds considerable complexity to the code and likely requires an additional layout iteration which I would like to prevent.

