### PR TITLE
[add] type diagram

### DIFF
--- a/src/lilaq.typ
+++ b/src/lilaq.typ
@@ -38,7 +38,7 @@
 #import "place-anchor.typ": place-anchor
 
 
-#import "typing.typ": set-grid, set-label, set-title, set-legend, set-tick, set-tick-label, set-spine, selector
+#import "typing.typ": set-grid, set-label, set-title, set-legend, set-tick, set-tick-label, set-spine, set-diagram, selector
 
 #import "logic/scale.typ"
 #import "algorithm/ticking.typ": locate-ticks-linear, locate-ticks-log, format-ticks-naive, format-ticks-linear, format-ticks-log

--- a/src/typing.typ
+++ b/src/typing.typ
@@ -5,6 +5,7 @@
 #import "model/legend.typ": legend
 #import "model/tick.typ": tick, tick-label
 #import "model/spine.typ": spine
+#import "model/diagram.typ": diagram
 
 #let set_ = e.set_
 #let set-grid = e.set_.with(grid)
@@ -14,3 +15,4 @@
 #let set-tick = e.set_.with(tick)
 #let set-tick-label = e.set_.with(tick-label)
 #let set-spine = e.set_.with(spine)
+#let set-diagram = e.set_.with(diagram)


### PR DESCRIPTION
This PR makes `diagram` an elembic element. This step grants so much power to users. 

For example setting the text size for all text in diagrams. 
```typ
#show lq.selector(lq.diagram): set text(.8em)
```


Or for creating templates
```typ
#let spectrum-plot = it => {
  show: lq.set-diagram(
    title: [Spectrum], 
    yscale: "log",
    ylabel: [Intensity],
    xlabel: [Wavelength],
  )
  it
}
```
which can be used like this:
```typ
#{
  show: spectrum-plot

  lq.diagram(
    lq.plot((1,2), (1,100))
  )
}
```