### PR TITLE
[change] default `z-index` values

### DIFF
--- a/src/model/diagram.typ
+++ b/src/model/diagram.typ
@@ -365,10 +365,10 @@
       }
     }
     let (xaxis-, max-xtick-size) = draw-axis(it.xaxis, axis-info.x.ticking, major-axis-style, e-get: e-get)
-    artists.push((content: xaxis-, z: 2.1))
+    artists.push((content: xaxis-, z: 20))
 
     let (yaxis-, max-ytick-size) = draw-axis(it.yaxis, axis-info.y.ticking, major-axis-style, e-get: e-get)
-    artists.push((content: yaxis-, z: 2.1))
+    artists.push((content: yaxis-, z: 20))
  
     if type(max-ytick-size) == array {
       for b in max-ytick-size {
@@ -387,7 +387,7 @@
     for axis in axes {
       let ticking = _axis-generate-ticks(axis, ..get-axis-args(axis))
       let (axis-, axis-bounds) = draw-axis(axis, ticking, major-axis-style, e-get: e-get)
-      artists.push((content: axis-, z: 2.1))
+      artists.push((content: axis-, z: 20))
 
       
       for b in axis-bounds {

--- a/src/model/diagram.typ
+++ b/src/model/diagram.typ
@@ -421,7 +421,7 @@
       
       let (title, b) = place-with-bounds(body, alignment: position, dx: dx, dy: dy, pad: pad)
       
-      artists.push((content: title, z: 3))
+      artists.push((content: title, z: 20))
       bounds = update-bounds(bounds, b)
     }
 

--- a/src/model/legend.typ
+++ b/src/model/legend.typ
@@ -64,7 +64,7 @@
   /// Specifies the $z$ position of the legend in the order of rendered
   /// diagram objects. 
   /// -> int | float
-  z-index: 6,
+  z-index: 25,
 
 ) = {}
 

--- a/src/plot/place.typ
+++ b/src/plot/place.typ
@@ -16,7 +16,7 @@
 /// ```
 /// 
 /// Unlike other plotting commands, @place is not clipped to the data area by
-/// default and the z-index is one higher, making the placed content appear 
+/// default and the z-index is higher, making the placed content appear 
 /// on top of most other diagram objects. 
 /// 
 /// ```example
@@ -78,7 +78,7 @@
   /// Determines the $z$ position of the content in the order of rendered diagram
   /// objects. See @plot.z-index.  
   /// -> int | float
-  z-index: 3,
+  z-index: 21,
 
 ) = {
   (


### PR DESCRIPTION
The changes are the following:

| element | old | new |
| ------- | ---- | --- |
| grid     | 0     |  0 |
| plots    | 2    |   2 |
| axis      | 2.1 | 20 |
| title      | 3    | 20 |
| place    | 3    | 21 |
| legend | 6    | 25 |

With the new defaults, there is a lot of space between the plots and the next-higher z value. This has the advantage that the user can easily control the z values of different plots without

a) running immediately into and over the `axis` default or
b) using floating point numbers. 

Notes:
- The relative order of the 5 elements above does not change. 
- The `z-index` of `title` and `axis` is not customizable (and has never been). Let's wait for someone to request this feature. 