### PR TITLE
Clearify diagram's width and height attributes

### DIFF
--- a/src/model/diagram.typ
+++ b/src/model/diagram.typ
@@ -25,11 +25,11 @@
 /// -> lq.diagram
 #let diagram(
   
-  /// The width of the diagram. 
+  /// The width of the diagram's data area (excluding axes ticks and labels). 
   /// -> length
   width: 6cm,
   
-  /// The height of the diagram. 
+  /// The height of the diagram's data area (excluding title, axes ticks and labels). 
   /// -> length
   height: 4cm,
 

--- a/src/model/diagram.typ
+++ b/src/model/diagram.typ
@@ -25,11 +25,11 @@
 /// -> lq.diagram
 #let diagram(
   
-  /// The width of the diagram's data area (excluding axes ticks and labels). 
+  /// The width of the diagram's data area (excluding axes, labels etc.). 
   /// -> length
   width: 6cm,
   
-  /// The height of the diagram's data area (excluding title, axes ticks and labels). 
+  /// The height of the diagram's data area (excluding axes, labels, title etc.). 
   /// -> length
   height: 4cm,
 


### PR DESCRIPTION
I know you might change that at some point, as mentioned in #15, but I think this is useful at least to clarify the current behaviour.