### PR TITLE
[add] `unit` to linear tick locator

### DIFF
--- a/src/algorithm/ticking.typ
+++ b/src/algorithm/ticking.typ
@@ -879,32 +879,3 @@
   log + linear.labels
 }
 
-
-
-#let format-multiple(
-  ticks, 
-  factor: auto,
-  body: none,
-  tick-info: (:),
-  ..args
-) = {
-  if factor == auto {
-    factor = tick-info.at("factor", default: 1)
-  }
-  ticks = ticks.map(tick => tick / factor)
-  let result = format-ticks-linear(
-    ticks, 
-    tick-info: tick-info,
-    ..args
-  )
-  result.labels = ticks.zip(result.labels).map(((tick, label)) => {
-    if tick == 0 { return $0$ }
-    tick = calc.round(tick, digits: 3)
-
-    if tick == 1 { label = none }
-    else if tick == -1 { label = "−"}
-
-    label + body
-  })
-  result
-}

--- a/src/algorithm/ticking.typ
+++ b/src/algorithm/ticking.typ
@@ -198,11 +198,11 @@
   density: 100%,
 
 
-  /// A base relative to which the tick distance is taken. This can for example
+  /// A unit relative to which the tick distance is taken. This can for example
   /// be used to generate ticks based on multiples of $\pi$ while keeping the
   /// flexibility of an automatically determined tick distance. 
   /// -> float
-  base: 1.0,
+  unit: 1.0,
 
   ..args
 
@@ -214,8 +214,8 @@
   if x1 < x0 {
     (x1, x0) = (x0, x1)
   }
-  x1 /= base
-  x0 /= base
+  x1 /= unit
+  x0 /= unit
 
   let step
   let exponent
@@ -260,9 +260,9 @@
   return (
     ticks: range(calc.min(max-ticks, num-ticks))
       .map(x => first-tick + x * tick-distance)
-      .map(x => x * base),
-    tick-distance: tick-distance * base,
-    base: base,
+      .map(x => x * unit),
+    tick-distance: tick-distance * unit,
+    unit: unit,
     
     // We provide additional args to ease the work of the formatter (in case it is
     // format-ticks-linear), because right now we have a lot of information. 
@@ -734,7 +734,7 @@
   ..args // important
 ) = {
   
-  let factor = tick-info.at("factor", default: 1)
+  let unit = tick-info.at("unit", default: 1)
 
   if offset == auto {
     offset = tick-info.at("offset", default: 0)
@@ -763,8 +763,8 @@
 
 
   let preapplied-exponent = inline-exponent + additional-exponent
-  let preapplied-factor = 1 / pow10(preapplied-exponent) / factor
-  let ticks = ticks.map(x => (x - offset) * preapplied-factor)
+  let preapplied-factor = 1 / pow10(preapplied-exponent) / unit
+  let ticks = ticks.map(x => (x - offset*unit) * preapplied-factor)
 
   
   let significant-digits = tick-info.at("significant-digits", default: none)

--- a/src/lilaq.typ
+++ b/src/lilaq.typ
@@ -45,6 +45,6 @@
 #import "typing.typ": set-grid, set-label, set-title, set-legend, set-tick, set-tick-label, set-spine, set-diagram, set-errorbar, selector, fields, elembic
 
 #import "logic/scale.typ"
-#import "algorithm/ticking.typ": locate-ticks-linear, locate-ticks-log, locate-ticks-symlog, locate-ticks-manual, locate-subticks-linear, locate-subticks-log, locate-subticks-symlog, format-ticks-linear, format-ticks-log, format-ticks-manual, 
+#import "algorithm/ticking.typ": locate-ticks-linear, locate-ticks-log, locate-ticks-symlog, locate-ticks-manual, locate-subticks-linear, locate-subticks-log, locate-subticks-symlog, format-ticks-linear, format-ticks-log, format-ticks-manual, format-multiple, format-ticks-symlog
 
 #import "theme/theme.typ"

--- a/src/lilaq.typ
+++ b/src/lilaq.typ
@@ -45,6 +45,6 @@
 #import "typing.typ": set-grid, set-label, set-title, set-legend, set-tick, set-tick-label, set-spine, set-diagram, set-errorbar, selector, fields, elembic
 
 #import "logic/scale.typ"
-#import "algorithm/ticking.typ": locate-ticks-linear, locate-ticks-log, locate-ticks-symlog, locate-ticks-manual, locate-subticks-linear, locate-subticks-log, locate-subticks-symlog, format-ticks-linear, format-ticks-log, format-ticks-manual, format-multiple, format-ticks-symlog
+#import "algorithm/ticking.typ": locate-ticks-linear, locate-ticks-log, locate-ticks-symlog, locate-ticks-manual, locate-subticks-linear, locate-subticks-log, locate-subticks-symlog, format-ticks-linear, format-ticks-log, format-ticks-manual, format-ticks-symlog
 
 #import "theme/theme.typ"


### PR DESCRIPTION
This makes it possible to specify a unit other than 1. This is for example useful to generate ticks that are multiples of $\pi$ (or any other real number). This is however more powerful than setting the tick distance because, the tick step is still smartly selected depending on the range − just based on $\pi$ multiples. 

At the same time, we introduce a `suffix` for the linear tick formatter that allows to add a suffix to each number, except when the number is 0, 1, or −1. Also, the linear tick formatter is aware of the `unit` that has been set with the locator. 


## Example 
```typ
#lq.diagram(
  xlim: (-2*calc.pi, 2*calc.pi),

  xaxis: (
    locate-ticks: lq.locate-ticks-linear.with(unit: calc.pi),
    format-ticks: lq.format-ticks-linear.with(suffix: $pi$)
  )
)
```
![image](https://github.com/user-attachments/assets/50019ead-b6bd-4b96-b10f-66758a555084)
