### PR TITLE
Implement Plot Smoothing

### DIFF
--- a/src/algorithm/bezier-interpolation.typ
+++ b/src/algorithm/bezier-interpolation.typ
@@ -1,0 +1,73 @@
+#import "linear-system.typ": thomas-algorithm
+
+/// Solve for a system of linear equations $A dot arrow(x) = arrow(b)$
+/// for the control points of the Bézier spline in either $x$ or $y$.
+///
+/// Returns an array of all control points (including start and end points) in $x$ or $y$.
+///
+/// -> array
+#let solve-control-points-1d(
+  /// The matrix $A$ of the system of linear equations.
+  /// -> array
+  A,
+  /// The vector $b$ of the system of linear equations.
+  /// -> array
+  b,
+  /// The dimension $n$ of the system of linear eqautions.
+  /// -> int
+  n,
+) = {
+  let s = range(2, n).map(i => (
+    2 * (2 * b.at(i - 1) + b.at(i))
+  ))
+  s.insert(0, b.at(0) + 2 * b.at(1))
+  s.push(8 * b.at(n - 1) + b.at(n))
+
+  // first control points
+  let c1 = thomas-algorithm(A, s)
+  // second control points
+  let c2 = range(0, n - 1).map(i => 2 * b.at(i + 1) - c1.at(i + 1))
+  c2.push(0.5 * (c1.at(n - 1) + b.at(n)))
+
+  let points = c1.zip(c2, b.slice(1)).flatten()
+  points.insert(0, b.at(0))
+
+  points
+}
+
+/// Calculate the control points (including start and end points) for a Bézier spline
+/// which interpolates the given data set.
+/// For the boundary conditions a curvature of 0 was chosen for the start and end points.
+///
+/// Math from https://omaraflak.medium.com/b%C3%A9zier-interpolation-8033e9a262c2
+///
+/// Returns an array of points (2D arrays).
+///
+/// -> array
+#let bezier-splines(
+  /// $x$ coordinates of the given points.
+  x,
+  /// $y$ coordinates of the given points.
+  y,
+) = {
+  let n = y.len() - 1
+
+  let A = ((0,) * (n),) * (n)
+  for i in range(1, n - 1) {
+    A.at(i).at(i) = 4
+    A.at(i + 1).at(i) = 1
+    A.at(i).at(i + 1) = 1
+  }
+  A.at(0).at(0) = 2
+  A.at(1).at(0) = 1
+  A.at(0).at(1) = 1
+  A.at(n - 1).at(n - 1) = 7
+  A.at(n - 1).at(n - 2) = 2
+
+  let points-x = solve-control-points-1d(A, x, n)
+  let points-y = solve-control-points-1d(A, y, n)
+
+  let points = points-x.zip(points-y)
+
+  points
+}

--- a/src/algorithm/linear-system.typ
+++ b/src/algorithm/linear-system.typ
@@ -1,0 +1,59 @@
+
+/// Solve a system of linear equations $A dot arrow(x) = arrow(b)$
+/// where $A$ is a tridiagonal matrix.
+/// See https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
+/// for more information.
+///
+/// Returns the solutions $arrow(x) in RR^n$ of the system of linear equqations.
+///
+/// -> array
+#let thomas-algorithm(
+  /// The matrix $A in RR^(n times n)$ of the system of linear equations.
+  /// The data format is an array of arrays, in row-major order.
+  ///
+  /// -> array
+  A,
+  /// The vector $arrow(b) in RR^n$ of the system of linear equations.
+  ///
+  /// -> array
+  b,
+) = {
+  let n = b.len()
+
+  if n == 1 {
+    return (b.at(0) / A.at(0).at(0),)
+  }
+
+  let beta = (0,) * n
+  let gamma = (0,) * n
+  let y = (0,) * n
+
+  beta.at(0) = A.at(0).at(0)
+  gamma.at(0) = A.at(0).at(1) / beta.at(0)
+  y.at(0) = b.at(0) / beta.at(0)
+
+  for i in range(1, n) {
+    let d-i = A.at(i).at(i)
+    let e-i = A.at(i).at(i - 1)
+    beta.at(i) = d-i - e-i * gamma.at(i - 1)
+
+    if i < n - 1 {
+      let c-i = A.at(i).at(i + 1)
+      gamma.at(i) = c-i / beta.at(i)
+    }
+
+    // backward elimination
+    y.at(i) = (b.at(i) - e-i * y.at(i - 1)) / beta.at(i)
+  }
+
+  let x = (0,) * n
+  x.at(n - 1) = y.at(n - 1)
+
+  // forward elimination
+  for i in range(n - 2, -1, step: -1) {
+    x.at(i) = y.at(i) - gamma.at(i) * x.at(i + 1)
+  }
+
+  x
+}
+


### PR DESCRIPTION
Fixes #47.

This PR adds a `smooth` option to the `plot` function, which interpolates the given data using Bézier splines instead of linear interpolation.

<details>
<summary>Example images</summary>

![image](https://github.com/user-attachments/assets/aa2b7ac9-7e90-4b39-8a0c-059687d3bcf8)

![image](https://github.com/user-attachments/assets/2f83ebaf-09e0-47f0-a6fa-9fdda59fcb3d)
</details>

Performance wise, calculating the control points for a data set of 2048 points took about 300 ms (Ryzen 7 5700X3D).
If performance with smoothing plots would ever become a problem, it might be worth looking into creating Rust plugin.
A naive implementation I quickly made was about 8 times faster.

I still need to add some tests, but I wanted to get feedback already.