### PR TITLE
[replace] table with grid in `legend`

### DIFF
--- a/src/model/legend.typ
+++ b/src/model/legend.typ
@@ -85,7 +85,7 @@
     inset: it.inset,
     fill: it.fill,
     radius: it.radius,
-    table(..it.children)
+    grid(..it.children)
   ),
 
   fields: (
@@ -159,13 +159,13 @@
     dx: dx, dy: dy, pad: pad,
     wrap-in-box: true,
     {
-      set table(
+      set grid(
         columns: 2, 
         stroke: none, 
         inset: 2pt, 
         align: horizon + start
       )
-      set table.cell(breakable: false)
+      set grid.cell(breakable: false)
       my-legend
     }
   )

--- a/tests/plot/fill-between/test.typ
+++ b/tests/plot/fill-between/test.typ
@@ -24,7 +24,7 @@
 
 
 #let fill-between = lq.fill-between.with(label: [])
-#show lq.selector(lq.legend): set table(columns: 4)
+#show lq.selector(lq.legend): set grid(columns: 4)
 
 // Cycling test
 #lq.diagram(

--- a/tests/plot/plot/self/test.typ
+++ b/tests/plot/plot/self/test.typ
@@ -5,7 +5,7 @@
 
 
 #let plot = lq.plot.with(label: [])
-#show lq.selector(lq.legend): set table(columns: 4)
+#show lq.selector(lq.legend): set grid(columns: 4)
 
 
 // Cycling test

--- a/tests/plot/plot/test.typ
+++ b/tests/plot/plot/test.typ
@@ -5,7 +5,7 @@
 
 
 #let plot = lq.plot.with(label: [])
-#show lq.selector(lq.legend): set table(columns: 4)
+#show lq.selector(lq.legend): set grid(columns: 4)
 
 
 // Cycling test

--- a/tests/plot/scatter/test.typ
+++ b/tests/plot/scatter/test.typ
@@ -13,7 +13,7 @@
 )
 
 
-#show lq.selector(lq.legend): set table(inset: 0pt)
+#show lq.selector(lq.legend): set grid(inset: 0pt)
 
 
 


### PR DESCRIPTION
This PR replaces the usage of `table` with `grid` for layouting the items of a `legend`. 

Semantically one could argue for both grid or table to be appropriate for a legend. However, tables are common to be styled globally in a document. It should be extremely rare that this should also affect the legend table, leading to undesired results, see #77. Grids on the other hand are much less likely to be styled globally. 


⚠️ This will require users to change rules of the form
```typ
#show lq.selector(lq.legend): set table(..)
```
to 
```typ
#show lq.selector(lq.legend): set grid(..)
```


Closes #77. 