### PR TITLE
Allow header names as converter names as well

### DIFF
--- a/src/loading/txt.typ
+++ b/src/loading/txt.typ
@@ -65,12 +65,17 @@
   let cols = array.zip(..rows) 
   if type(converters) == dictionary {
     let default-converter = converters.at("rest", default: float)
-    cols = range(cols.len()).map(j => {
-      let converter = if header == false { 
-        converters.at(str(j), default: default-converter)
-      } else {
-        converters.at(header.at(j), default: converters.at(str(j), default: default-converter))
+
+    if header != false {
+      for name in converters.keys() {
+        if name == "rest" { continue }
+        assert(name in header, message: "Found converter that doesn't map to a header: " + repr(name))
       }
+    }
+
+    cols = range(cols.len()).map(j => {
+      let name = if header == false { str(j) } else { header.at(j) }
+      let converter = converters.at(name, default: default-converter)
       cols.at(j).map(str.trim).map(converter)
     })
   } else {
@@ -153,6 +158,6 @@
 
 
 #assert.eq(
-   load-txt(" n, a, b\n1,2,3\n4,5,6", header: true, converters: ("n": v => v, "2": v => v)),
+   load-txt(" n, a, b\n1,2,3\n4,5,6", header: true, converters: (n: v => v, a: v => v, rest: v => v)),
    (n: ("1","4"), a: (2,5), b: ("3","6"))
 )

--- a/src/loading/txt.typ
+++ b/src/loading/txt.typ
@@ -158,6 +158,6 @@
 
 
 #assert.eq(
-   load-txt(" n, a, b\n1,2,3\n4,5,6", header: true, converters: (n: v => v, a: v => v, rest: v => v)),
+   load-txt(" n, a, b\n1,2,3\n4,5,6", header: true, converters: (n: v => v, a: int, rest: v => v)),
    (n: ("1","4"), a: (2,5), b: ("3","6"))
 )

--- a/src/loading/txt.typ
+++ b/src/loading/txt.typ
@@ -38,7 +38,7 @@
   
   /// Optional converter functions or types to use to convert the data entries. This
   /// can either be a single function or type that is applied to all columns likewise
-  /// or a dictionary with column indices as keys and functions or types as values. 
+  /// or a dictionary with column indices, or header names if enabled, as keys and functions or types as values. 
   /// Through the (optional) key `rest`, a default converter can be specified to be used 
   /// for all columns that have no explicit converter assigned. 
   /// -> function | type | dictionary
@@ -66,7 +66,11 @@
   if type(converters) == dictionary {
     let default-converter = converters.at("rest", default: float)
     cols = range(cols.len()).map(j => {
-      let converter = converters.at(str(j), default: default-converter)
+      let converter = if header == false { 
+        converters.at(str(j), default: default-converter)
+      } else {
+        converters.at(header.at(j), default: converters.at(str(j), default: default-converter))
+      }
       cols.at(j).map(str.trim).map(converter)
     })
   } else {

--- a/src/loading/txt.typ
+++ b/src/loading/txt.typ
@@ -150,3 +150,9 @@
    load-txt("1,2\n4,5", converters: ("0": float, rest: v => v)),
    ((1, 4), ("2","5"))
 )
+
+
+#assert.eq(
+   load-txt(" n, a, b\n1,2,3\n4,5,6", header: true, converters: ("n": v => v, "2": v => v)),
+   (n: ("1","4"), a: (2,5), b: ("3","6"))
+)


### PR DESCRIPTION
While playing around with the `load-txt` function, I found it very unintuitive that you can't use the column names, as defined by the header, to define converters. This PR amends that while still retaining the column index based converter definitions when headers are enabled.

Please note that I didn't go through the long-winded route of opening an issue for this, as I assumed that this was too small of a change to warrant the paper trail.