### PR TITLE
Fix wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Clicking on any demo image below will bring you to the respective page of the do
 </td>
 <td>
 
-[![bar chart](https://github.com/user-attachments/assets/7822cc4f-6f12-4622-9f38-18ca7dd2a4fa)](https://lilaq.org/docs/examples/bar)
+[![bar chart](https://github.com/user-attachments/assets/7822cc4f-6f12-4622-9f38-18ca7dd2a4fa)](https://lilaq.org/docs/reference/bar)
 
 </td>
 </tr>


### PR DESCRIPTION
The old link was leading to an 404 not found error.



P. S.: As this is only a small bug, I decided to not go the detour of opening an issue. I hope you agree 😃 