### PR TITLE
[add] parameter `pad` to `tick-format.linear`

### DIFF
--- a/src/logic/tick-format.typ
+++ b/src/logic/tick-format.typ
@@ -147,9 +147,8 @@
     significant-digits += preapplied-exponent
   }
 
-  if pad {
-    ticks = ticks.map(calc.round.with(digits: significant-digits))
-  } else {
+  ticks = ticks.map(calc.round.with(digits: significant-digits))
+  if not pad {
     significant-digits = auto
   }
 


### PR DESCRIPTION
Can be used via
```typ
#show: lq.set-diagram(
  xaxis: (format-ticks: lq.tick-format.linear.with(pad: false)),
)

#lq.diagram()
```
<img width="463" height="315" alt="image" src="https://github.com/user-attachments/assets/2d96c1bd-5a0b-412d-b0dc-ee3f3e8ce95c" />

In the future there might be a settable element that allows `set`ting such values like `set lq.tick.format.args(pad: false)` which would be useful so that the formatter can stay `auto` and may adapt the current scale (i.e. pick the log formatter when the axis is logarithmic). 

Closes #126. 