### PR TITLE
[fix] inverted colorbar

### DIFF
--- a/src/plot/rect.typ
+++ b/src/plot/rect.typ
@@ -107,18 +107,27 @@
         align: twod-ify-alignment(align)
       )
 
-      place(dx: x1, dy: y1, 
-        std.rect(
-          width: width, 
-          height: height, 
+
+      let rect = std.rect.with(
           fill: fill, 
           stroke: stroke,
           radius: radius, 
           inset: inset, 
           outset: outset,
           body
-        )
       )
+
+      let content = rect(width: width, height: height)
+
+      if (type(height) == length and height < 0pt) or (type(height) == ratio and height < 100%) {
+        y1 += height
+        content = rect(width: width, height: -height)
+        if type(fill) == gradient {
+          content = scale(y: -100%, content)
+        }
+      }
+      
+      place(dx: x1, dy: y1, content)
     },
     xlimits: compute-primitive-limits.with((x, if all-data-coordinates((x, width)) { x + width } else { x })),
     ylimits: compute-primitive-limits.with((y, if all-data-coordinates((y, height)) { y + height } else { y })),


### PR DESCRIPTION
Vertical color bars are exported to PDF with the gradient inverted. This is a bug with PDF export with Typst when a rectangle with negative height is created, see https://github.com/typst/typst/issues/6597. Until they fix it, this PR is a temporary workaround. 

Closes #85, closes #129