### PR TITLE
[add] allow diagram dimensions to accept em lengths

### DIFF
--- a/src/bounds.typ
+++ b/src/bounds.typ
@@ -11,7 +11,7 @@
 
 
 #let update-bounds(former, bounds, width: 0cm, height: 0cm) = (
-  left: calc.min(former.left, get-length(bounds.left, width).to-absolute()), 
+  left: calc.min(former.left, get-length(bounds.left, width).to-absolute()),
   top: calc.min(former.top, get-length(bounds.top, height).to-absolute()),
   right: calc.max(former.right, get-length(bounds.right, width).to-absolute()),
   bottom: calc.max(former.bottom, get-length(bounds.bottom, height).to-absolute()),

--- a/src/model/axis.typ
+++ b/src/model/axis.typ
@@ -534,10 +534,11 @@
   let (exp, offset) = (axis.exponent, axis.offset)
 
   let em = measure(line(length: 1em, angle: 0deg)).width
+  let abs-length = length.to-absolute()
   axis.tick-args.num-ticks-suggestion = match(
     axis.kind,
-    "x", length / (3.3 * em),
-    "y", length / (2 * em)
+    "x", abs-length / (3.3 * em),
+    "y", abs-length / (2 * em)
   )
   let (x0, x1) = axis.lim
   

--- a/src/model/diagram.typ
+++ b/src/model/diagram.typ
@@ -642,8 +642,8 @@
 
     let (xaxis, yaxis) = axes.slice(0, 2)
 
-    let bounds = (left: 0pt, right: it.width, top: 0pt, bottom: it.height)
-    let update-bounds = update-bounds.with(width: it.width, height: it.height)
+    let bounds = (left: 0pt, right: it.width.to-absolute(), top: 0pt, bottom: it.height.to-absolute())
+    let update-bounds = update-bounds.with(width: it.width.to-absolute(), height: it.height.to-absolute())
     
     let diagram = box(
       width: it.width, height: it.height, 


### PR DESCRIPTION
## PR Summary
This PR adds support to em-based diagram sizing by resolving absolute bounds and adjusting tick heuristics.

Fixes #132.