### PR TITLE
[fix] conversion of rect coordinates with nonlinear scales and alignment

### DIFF
--- a/src/logic/process-coordinates.typ
+++ b/src/logic/process-coordinates.typ
@@ -142,25 +142,39 @@
 
   // at the end we only want (relative) lengths
 
-  let (x1, y1)  = transform-point(x, y, transform)
   if type(width) in (int, float) {
     assert(type(x) in (int, float), message: "Setting the width in terms of data coordinates is only allowed if the origin x coordinate is given in data coordinates")
+    
+    if align.x != left {
+      if align.x == right { x -= width }
+      else if align.x == center { x -= width / 2 }
+      align = align.y + left
+    }
     width = transform(x + width, 1).at(0) - transform(x, 1).at(0)
+
   }
 
   if type(height) in (int, float) {
     assert(type(y) in (int, float), message: "Setting the height in terms of data coordinates is only allowed if the origin y coordinate is given in data coordinates")
+
+    if align.y != top {
+      if align.y == bottom { y -= height }
+      else if align.y == horizon { y -= height / 2 }
+      align = align.x + top
+    }
     height = transform(1, y + height).at(1) - transform(1, y).at(1) 
   }
 
-  if align.x == right { x1 -= width }
-  else if align.x == center { x1 -= width / 2 }
+  let (x, y)  = transform-point(x, y, transform)
+
+  if align.x == right { x -= width }
+  else if align.x == center { x -= width / 2 }
   
-  if align.y == bottom { y1 -= height }
-  else if align.y == horizon { y1 -= height / 2 }
+  if align.y == bottom { y -= height }
+  else if align.y == horizon { y -= height / 2 }
 
 
-  return (x1, width, y1, height)
+  return (x, width, y, height)
 }
 
 #let is-data-coordinates(coord) = type(coord) in (int, float)


### PR DESCRIPTION
This is used with `lq.rect` and `lq.ellipse` to resolve the different possible types of coordinates.