### PR TITLE
[fix] layout failing when other elements than grid cells are used

### DIFF
--- a/src/layout.typ
+++ b/src/layout.typ
@@ -81,7 +81,7 @@
 
   // protect other grids such as the legend grid
   // if it.children.all(cell => e.eid(cell.body) != e.eid(diagram)) { return it }
-  if it.children.all(cell => not is-styled-diagram(cell.body)) { return it }
+  if it.children.all(cell => cell.func() != grid.cell or not is-styled-diagram(cell.body)) { return it }
   
   
   let grid = context {

--- a/tests/layout/test.typ
+++ b/tests/layout/test.typ
@@ -30,6 +30,8 @@
 
   // - rows
   #grid(
+    grid.vline(),
+    grid.hline(),
     lq.diagram(
       ylim: (10, 100),
     ),


### PR DESCRIPTION
such as `grid.vline` or `grid.header`.

Fixes #171. 