### PR TITLE
Document how to set fixed size of full diagram (including axes, labels, title, etc.)

### DIFF
--- a/src/model/diagram.typ
+++ b/src/model/diagram.typ
@@ -41,11 +41,12 @@
   
   /// The width of the diagram. This can be one of the following:
   /// - A `length`, defining just the width of the data area,
-  ///   excluding axes, labels, title, etc. (To set a `length` including axes,
-  ///   labels, etc., use `0% + length`)
+  ///   excluding axes, labels, title, etc. To set a `length` including 
+  ///   everything, use `0% + length`, see the next option. 
   /// - A `ratio` or `relative` where the ratio part is relative to the width 
-  ///   of the parent that the diagram is placed in. This is not allowed if the
-  ///   parent has an unbounded width, e.g., a page with `width: auto`.  
+  ///   of the parent that the diagram is placed in. This includes axes, labels, 
+  ///   title, etc. This is not allowed if the parent has an unbounded width, 
+  ///   e.g., a page with `width: auto`.  
   /// - Or `auto` in which case the width is computed automatically based on 
   ///   @diagram.aspect-ratio. 
   /// -> length | relative | auto
@@ -53,11 +54,12 @@
   
   /// The height of the diagram. This can be one of the following:
   /// - A `length`, defining just the height of the data area,
-  ///   excluding axes, labels, title, etc. (To set a `length` including axes,
-  ///   labels, etc., use `0% + length`)
+  ///   excluding axes, labels, title, etc. To set a `length` including 
+  ///   everything, use `0% + length`, see the next option. 
   /// - A `ratio` or `relative` where the ratio part is relative to the height 
-  ///   of the parent that the diagram is placed in. This is not allowed if the
-  ///   parent has an unbounded height, e.g., a page with `height: auto`.  
+  ///   of the parent that the diagram is placed in. This includes axes, labels, 
+  ///   title, etc. This is not allowed if the parent has an unbounded height, 
+  ///   e.g., a page with `height: auto`.  
   /// - Or `auto` in which case the height is computed automatically based on 
   ///   @diagram.aspect-ratio. 
   /// -> length | relative | auto


### PR DESCRIPTION
Hi,

I found this little trick while trying to place a `lq.diagram` into a `layout(size => ...)` to size it. At first I was quite confused why the diagram was bigger than the layout size, until I found mention in the docs that a `length` value is just the data area, excluding axes, labels, etc.  Only a `ratio` value will be used for the full width/height, including axes, labels, etc.

So I figured out that I can make a length into a ratio by just writing `0% + length`, so overall this does the trick:

```typst
#block(height: 1fr, layout(size => lq.diagram(
  width: 0% + size.width,
  height: 0% + size.height,

  // ...
)))
```

I think this is a bit of a surprising behavior so I wanted to start the discussion about it.

But in any case I think it would help others to document how you can do this because I'm surely not the only one who will attempt this.  So in this PR I just add docs to explain this.