### PR TITLE
[fix] rounding with Zero

### DIFF
--- a/src/logic/tick-format.typ
+++ b/src/logic/tick-format.typ
@@ -62,7 +62,8 @@
     ), 
     base: base, 
     digits: digits, 
-    omit-unity-mantissa: omit-unit-mantissa
+    omit-unity-mantissa: omit-unit-mantissa,
+    round: (precision: none),
   )
 }
 

--- a/src/model/axis.typ
+++ b/src/model/axis.typ
@@ -918,14 +918,14 @@
 
   let attachment = none
   if type(offset) in (int, float) and offset != 0 {
-    attachment += zero.num(positive-sign: true, offset)
+    attachment += zero.num(positive-sign: true, offset, round: (precision: none))
   } else if offset not in (0, auto) {
     attachment += offset
   }
   if type(exp) == int and exp != 0 {
     attachment += {
       show "X": none
-      zero.num("Xe" + str(exp))
+      zero.num("Xe" + str(exp), round: (precision: none))
     }
   }
 


### PR DESCRIPTION
Always disable rounding for ticks and exponents/offsets.

Closes #194.