### PR TITLE
Add `geomspace` function

### DIFF
--- a/src/math.typ
+++ b/src/math.typ
@@ -138,6 +138,50 @@
 
 ) = linspace(start, end, num: num, include-end: include-end).map(x => calc.pow(base, x))
 
+#let geomspace(
+
+  /// Start of the range.
+  /// -> int | float
+  start,
+
+  /// End of the range.
+  /// -> int | float
+  end,
+
+  /// Number of evenly-spaced values to produce. 
+  /// -> int
+  num: 50,
+
+  /// Whether to include the end of the range. If `true`, samples are taken for
+  /// the closed interval `[start, end]`. Otherwise, the last point is omitted. 
+  /// -> bool
+  include-end: true,
+
+) = {
+  // This algorithm mirrors the official numpy implementation
+  assert(num >= 0, message: "geomspace: num must be non-negative")
+  
+  if num == 0 { return () }
+  if num == 1 { return (start,) }
+
+  let denom = num - int(include-end)
+  
+  // transformation to log-space
+  let log-start = calc.ln(start)
+  let log-end = calc.ln(end)
+  let log-step = (log-end - log-start) / denom
+
+  range(0, num).map(v => {
+    if v == 0 {
+      float(start)
+    } else if include-end and v == num - 1 {
+      float(end)
+    } else {
+      // backtransform to linear space
+      calc.exp(log-start + log-step * v)
+    }
+  })
+}
 
 /// Generates an array of numbers spaced by `step` in the interval `[start, end)`. 
 /// -> array

--- a/src/math.typ
+++ b/src/math.typ
@@ -76,7 +76,7 @@
 
 
 
-/// Generates an array of evenly-spaced numbers in the interval `[start, end)` or `[start, end]`. 
+/// Generates an array of evenly-spaced numbers in the interval `[start, end)` or ` [start, end]`. 
 /// -> array
 #let linspace(
   
@@ -106,7 +106,7 @@
 }
 
 
-/// Generates an array of logarithmically-spaced numbers in the interval `[base^start, base^end)` or `[base^start, base^end]`.
+/// Generates an array of logarithmically-spaced numbers in the interval `[base^start, base^end)` or ` [base^start, base^end]`.
 /// Useful for displaying functions on a log-scaled diagram. 
 /// ```typ
 /// #lq.logspace(-4, 4, num: 8, include-end: false)
@@ -138,6 +138,13 @@
 
 ) = linspace(start, end, num: num, include-end: include-end).map(x => calc.pow(base, x))
 
+/// Generates an array of numbers spaced evenly on a log scale (geometric progression) in the interval `[start, end)` or ` [start, end]`.
+/// Unlike `logspace`, the endpoints are specified directly rather than as exponents. 
+/// ```typ
+/// #lq.geomspace(1, 1000, num: 4)
+/// ```
+/// This returns values from 1 to 1000: `(1.0, 10.0, 100.0, 1000.0)`.
+/// -> array
 #let geomspace(
 
   /// Start of the range.
@@ -148,7 +155,7 @@
   /// -> int | float
   end,
 
-  /// Number of evenly-spaced values to produce. 
+  /// Number of values with evenly-spaced logarithms.
   /// -> int
   num: 50,
 

--- a/src/math.typ
+++ b/src/math.typ
@@ -160,26 +160,37 @@
 ) = {
   // This algorithm mirrors the official numpy implementation
   assert(num >= 0, message: "geomspace: num must be non-negative")
+  assert(
+    (start > 0 and end > 0) or (start < 0 and end < 0),
+    message: "geomspace: start and end must have the same sign and must not be zero",
+  )
   
   if num == 0 { return () }
   if num == 1 { return (start,) }
-
+  
+  let is-negative = start < 0
+  let abs-start = calc.abs(start)
+  let abs-end = calc.abs(end)
+  
   let denom = num - int(include-end)
   
   // transformation to log-space
-  let log-start = calc.ln(start)
-  let log-end = calc.ln(end)
+  let log-start = calc.ln(abs-start)
+  let log-end = calc.ln(abs-end)
   let log-step = (log-end - log-start) / denom
-
+  
   range(0, num).map(v => {
-    if v == 0 {
-      float(start)
+    let val = if v == 0 {
+      float(abs-start)
     } else if include-end and v == num - 1 {
-      float(end)
+      float(abs-end)
     } else {
       // backtransform to linear space
       calc.exp(log-start + log-step * v)
     }
+    
+    // restore sign
+    if is-negative { -val } else { val }
   })
 }
 

--- a/src/math.typ
+++ b/src/math.typ
@@ -175,8 +175,8 @@
   let denom = num - int(include-end)
   
   // transformation to log-space
-  let log-start = calc.ln(abs-start)
-  let log-end = calc.ln(abs-end)
+  let log-start = calc.log(abs-start)
+  let log-end = calc.log(abs-end)
   let log-step = (log-end - log-start) / denom
   
   range(0, num).map(v => {
@@ -186,7 +186,7 @@
       float(abs-end)
     } else {
       // backtransform to linear space
-      calc.exp(log-start + log-step * v)
+      calc.pow(10.0, log-start + log-step * v)
     }
     
     // restore sign

--- a/tests/math/test.typ
+++ b/tests/math/test.typ
@@ -31,8 +31,18 @@
 
 // Close equal for floating point equality checks
 #let assert-close-eq(a, b, tol: 1e-8) = {
-  assert(a.len() == b.len(), message: "Test failed: Arrays have different lengths")
-  assert(a.zip(b).all(((a, b)) => calc.abs(a - b) <= tol), message: "Test failed: Non matching arrays")
+  assert(
+    a.len() == b.len(),
+    message: ("Test failed: Arrays have different lengths: " + str(a.len())) + " != " + str(b.len()),
+  )
+  assert(
+    a.zip(b).all(((a, b)) => calc.abs(a - b) <= tol),
+    message: "Test failed: Non matching arrays: ("
+      + a.map(str).join(", ")
+      + ") not approximately equal to ("
+      + b.map(str).join(", ")
+      + ")",
+  )
 }
 
 // Normal operation
@@ -46,6 +56,7 @@
 #assert-close-eq(geomspace(1, 1000, num: 2), (1., 1000.))
 #assert-close-eq(geomspace(1, 100, num: 3), (1., 10., 100.))
 #assert-close-eq(geomspace(10.5, 1050, num: 3), (10.5, 105., 1050.))
+#assert-close-eq(geomspace(-10.5, -1050, num: 3), (-10.5, -105., -1050.))
 #assert-close-eq(geomspace(1, 100, num: 2, include-end: false), (1., 10.))
 #assert-close-eq(geomspace(1, 1000, num: 2), (1., 1000.))
 #assert-close-eq(geomspace(1, 1000000, num: 7), (1., 10., 100., 1000., 10000., 100000., 1000000.))

--- a/tests/math/test.typ
+++ b/tests/math/test.typ
@@ -26,6 +26,14 @@
 #assert.eq(linspace(-2.3, 1, num: 1, include-end: false), (-2.3, ))
 #assert.eq(logspace(-1, 1, num: 1), (0.1,))
 #assert.eq(logspace(-1, 1, num: 1, include-end: false), (0.1,))
+#assert.eq(geomspace(1, 2, num: 0), ())
+#assert.eq(geomspace(1, 2, num: 1), (1,))
+
+// Close equal for floating point equality checks
+#let assert-close-eq(a, b, tol: 1e-8) = {
+  assert(a.len() == b.len(), message: "Test failed: Arrays have different lengths")
+  assert(a.zip(b).all(((a, b)) => calc.abs(a - b) <= tol), message: "Test failed: Non matching arrays")
+}
 
 // Normal operation
 #assert.eq(linspace(0, 1, num: 2), (0, 1))
@@ -35,6 +43,12 @@
 #assert.eq(linspace(0, 1, num: 5), (0, .25, .5, .75, 1))
 #assert.eq(logspace(0, 1, num: 2), (1, 10))
 #assert.eq(logspace(0, 2, num: 2, include-end: false), (1, 10))
+#assert-close-eq(geomspace(1, 1000, num: 2), (1., 1000.))
+#assert-close-eq(geomspace(1, 100, num: 3), (1., 10., 100.))
+#assert-close-eq(geomspace(10.5, 1050, num: 3), (10.5, 105., 1050.))
+#assert-close-eq(geomspace(1, 100, num: 2, include-end: false), (1., 10.))
+#assert-close-eq(geomspace(1, 1000, num: 2), (1., 1000.))
+#assert-close-eq(geomspace(1, 1000000, num: 7), (1., 10., 100., 1000., 10000., 100000., 1000000.))
 
 // Inverse range
 #assert.eq(linspace(1, 0, num: 2), (1, 0))
@@ -42,6 +56,8 @@
 #assert.eq(linspace(100, 0, num: 2, include-end: false), (100, 50))
 #assert.eq(logspace(1, 0, num: 2), (10.0, 1.0))
 #assert.eq(logspace(-2, 0, num: 2, include-end: false), (0.01, 0.1))
+#assert-close-eq(geomspace(100,1,num:3), (100.,10.,1.))
+#assert-close-eq(geomspace(100, 1, num:2, include-end: false), (100., 10.))
 
 #assert.eq(arange(0, 1), (0,))
 #assert.eq(arange(0, 2), (0,1))


### PR DESCRIPTION
This PR is in reference to #209 .
I originally intended to mirror the [numty](https://github.com/PabloRuizCuevas/numty/blob/15c5dae3e82f3c3fff9b67bca45e30f64a63fd97/lib.typ#L353) version for it's simplicity, but ultimately settled for the algorithm that [Numpy](https://numpy.org/doc/stable/reference/generated/numpy.geomspace.html) uses under the hood, which should yield better performance for larger arrays (by avoiding pow inside the hotloop), although I did not empirically test this.

As I ran into issues with float equality checks not passing in the test suite I added a small helper function that checks for equality inside a tolerance.

```typst
// Close equal for floating point equality checks
#let assert-close-eq(a, b, tol: 1e-8) = {
  assert(a.len() == b.len(), message: "Test failed: Arrays have different lengths")
  assert(a.zip(b).all(((a, b)) => calc.abs(a - b) <= tol), message: "Test failed: Non matching arrays")
}
```

The commits were squashed into one to make review easier aswell. Please let me know if you want me to change anything before merging!