### PR TITLE
[add] plot-function

### DIFF
--- a/src/lilaq.typ
+++ b/src/lilaq.typ
@@ -17,7 +17,7 @@
 
 #import "layout.typ": layout
 
-#import "plot/plot.typ": plot
+#import "plot/plot.typ": plot, plot-function
 #import "plot/bar.typ": bar
 #import "plot/hbar.typ": hbar
 #import "plot/stem.typ": stem

--- a/src/plot/plot.typ
+++ b/src/plot/plot.typ
@@ -7,6 +7,7 @@
 #import "../style/styling.typ": mark, prepare-mark, prepare-path
 #import "../model/errorbar.typ": errorbar, generate-xerrorbar, generate-yerrorbar
 #import "../logic/time.typ"
+#import "../math.typ": linspace
 #import "@preview/tiptoe:0.4.0"
 
 #let get-errorbar-stroke(base-stroke) = {
@@ -443,5 +444,75 @@
     ignores-cycle: not use-cycle,
     clip: clip,
     z-index: z-index
+  )
+}
+
+
+
+/// Plots a function over a finite domain without requiring an explicit array
+/// of $x$ coordinates.
+///
+/// The function is evaluated at uniformly spaced points across
+/// @plot-function.domain.
+/// By default, the generated curve has no marks and uses Bézier interpolation
+/// for a smooth appearance. The number of evaluation points can be configured
+/// through @plot-function.samples.
+///
+/// ```example
+/// #lq.diagram(
+///   lq.plot-function(
+///     (-calc.pi, calc.pi),
+///     calc.sin,
+///   )
+/// )
+/// ```
+///
+/// Additional named arguments are forwarded to @plot. This can be used to
+/// style the curve or override the default `mark: none` and `smooth: true`
+/// options.
+#let plot-function(
+
+  /// The start and end of the interval on which to evaluate @plot-function.f.
+  /// -> array
+  domain,
+
+  /// A function that maps an $x$ coordinate to a $y$ coordinate.
+  /// -> function
+  f,
+
+  /// Number of uniformly spaced points at which to evaluate @plot-function.f.
+  /// -> int
+  samples: 200,
+
+  /// Additional named arguments to pass to @plot.
+  /// -> any
+  ..args,
+
+) = {
+  assert(
+    type(f) == function,
+    message: "plot-function: f must be a function",
+  )
+  assert(
+    type(domain) == array and domain.len() == 2,
+    message: "plot-function: domain must contain exactly two values",
+  )
+  assert(
+    domain.all(value => type(value) in (int, float)),
+    message: "plot-function: domain values must be numbers",
+  )
+  assert(
+    type(samples) == int and samples >= 2,
+    message: "plot-function: samples must be an integer greater than one",
+  )
+
+  let (start, end) = domain
+  plot.with(
+    mark: none,
+    smooth: true,
+  )(
+    linspace(start, end, num: samples),
+    f,
+    ..args,
   )
 }

--- a/tests/plot/plot-function/test.typ
+++ b/tests/plot/plot-function/test.typ
@@ -1,0 +1,43 @@
+#import "/src/lilaq.typ" as lq
+
+
+#let curve = lq.plot-function(
+  (-2, 2),
+  x => x * x,
+  samples: 5,
+)
+
+#assert.eq(curve.x, (-2, -1, 0, 1, 2))
+#assert.eq(curve.y, (4, 1, 0, 1, 4))
+#assert.eq(curve.mark.mark, none)
+#assert.eq(curve.style.smooth, true)
+#assert.eq((curve.xlimits)(), (-2, 2))
+#assert.eq((curve.ylimits)(), (0, 4))
+
+
+#let styled = lq.plot-function(
+  (0, calc.pi),
+  calc.sin,
+  samples: 3,
+  mark: "o",
+  smooth: false,
+  color: red,
+  label: [Sine],
+)
+
+#assert.eq(styled.x, (0, calc.pi / 2, calc.pi))
+#assert.eq(styled.mark.mark, "o")
+#assert.eq(styled.style.smooth, false)
+#assert.eq(styled.style.color, red)
+#assert.eq(styled.label, [Sine])
+
+
+#let default = lq.plot-function((1, 3), x => x)
+#assert.eq(default.x.len(), 200)
+#assert.eq(default.x.first(), 1)
+#assert.eq(default.x.last(), 3)
+
+
+#assert-panic(() => lq.plot-function((0,), x => x))
+#assert-panic(() => lq.plot-function((0, 1), 1))
+#assert-panic(() => lq.plot-function((0, 1), x => x, samples: 1))


### PR DESCRIPTION
Closes #216.

Thanks for the helpful API discussion in the issue. This adds the agreed
`lq.plot-function(domain, f, samples: 200, ..args)` wrapper.

It samples the explicit domain uniformly and delegates rendering to `plot`.
Function plots default to `mark: none` and `smooth: true`, while forwarded plot
arguments can override those defaults and style the curve normally.

```typ
#lq.diagram(
  lq.plot-function(
    (-calc.pi, calc.pi),
    calc.sin,
  )
)
```

Tests cover sampling, function evaluation, defaults, overrides, forwarded
styling, limits, and invalid arguments. The full suite passes: 77/77.
